### PR TITLE
Updating static_activity_indices if database has "static" attribute

### DIFF
--- a/bw_temporalis/lca.py
+++ b/bw_temporalis/lca.py
@@ -97,11 +97,8 @@ class TemporalisLCA:
         )
         for db in bd.databases:
             if bd.databases[db].get("static"):
-                static_activity_indices.add(
-                    {
-                        obj[0]
-                        for obj in AD.select(AD.id).where(AD.database == db).tuples()
-                    }
+                static_activity_indices.update(
+                    obj[0] for obj in AD.select(AD.id).where(AD.database == db).tuples()
                 )
 
         print("Starting graph traversal")


### PR DESCRIPTION
Using the "static" attribute on whole databases caused an error when adding their ids to the static_activity_indices set. Instead of trying to add a set to another set, it's now using set.update().

<img width="632" alt="image" src="https://github.com/brightway-lca/bw_temporalis/assets/90762029/98ff3f31-32de-45fd-b49d-273933da878b">
