### PR TITLE
Improving performance of dynamic characterization

### DIFF
--- a/bw_temporalis/timeline.py
+++ b/bw_temporalis/timeline.py
@@ -235,12 +235,16 @@ class Timeline:
         if flow:
             df = df.loc[self.df["flow"].isin(flow)]
         df.reset_index(drop=True, inplace=True)
-        result_df = pd.concat(
-            [characterization_function(row) for _, row in df.iterrows()]
+        result_df = pd.DataFrame(
+            [characterization_function(row) for row in df.itertuples(index=False)]
         )
         if "date" in result_df.columns:
-            result_df.sort_values(by="date", ascending=True, inplace=True)
-            result_df.reset_index(drop=True, inplace=True)
+            result_df = (
+                result_df.explode(["amount", "date"])
+                .astype({"amount": "float64"})
+                .sort_values(by="date")
+                .reset_index(drop=True)
+            )
         if cumsum and "amount" in result_df:
             result_df["amount_sum"] = result_df["amount"].cumsum()
         return result_df

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 from bw2calc import LCA
 from bw2data.tests import bw2test
+from collections import namedtuple
 
 from bw_temporalis import TemporalisLCA, easy_timedelta_distribution
 from bw_temporalis.temporal_distribution import TemporalDistribution
@@ -111,24 +112,22 @@ def define_dataframes() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     return (df_input, df_expected_characterize, df_expected_sum_days_to_years)
 
 
-def function_characterization_test(series: pd.Series, period: int = 2) -> pd.DataFrame:
-    date_beginning: np.datetime64 = series["date"].to_numpy()
+def function_characterization_test(series: namedtuple, period: int = 2) -> namedtuple:
+    date_beginning: np.datetime64 = series.date.to_numpy()
     dates_characterized: np.ndarray = date_beginning + np.arange(
         start=0, stop=period, dtype="timedelta64[Y]"
     ).astype("timedelta64[s]")
 
-    amount_beginning: float = series["amount"]
+    amount_beginning: float = series.amount
     amount_characterized: np.ndarray = amount_beginning - np.arange(
         start=0, stop=period, dtype="int"
     )
 
-    return pd.DataFrame(
-        {
-            "date": pd.Series(data=dates_characterized.astype("datetime64[s]")),
-            "amount": pd.Series(data=amount_characterized, dtype="float64"),
-            "flow": series.flow,
-            "activity": series.activity,
-        }
+    return namedtuple("CharacterizedRow", ["date", "amount", "flow", "activity"])(
+        date=np.array(dates_characterized, dtype="datetime64[s]"),
+        amount=amount_characterized,
+        flow=series.flow,
+        activity=series.activity,
     )
 
 


### PR DESCRIPTION
The current implementation of the dynamic characterization does not scale very well. The main issue is the repeated creation of pd.Series at several points when characterizing of each row of the inventory df. 

Instead of handling pd.Series and DataFrames all the time, I switched it to namedtuple. In an example case, this reduced computing time from ~30s to <1s. 

I've also noticed that the test for dynamic characterization seem to be incomplete, but some preparation has been done. I can try do add this, so I'll keep this PR as a draft for now.